### PR TITLE
fix: not creating new instance on each access of binding

### DIFF
--- a/.changeset/orange-bears-run.md
+++ b/.changeset/orange-bears-run.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Fix accessing an instance of a binding multiple times interfacing on the same instance - create a new proxy instance for each time the binding is accessed.

--- a/.changeset/orange-bears-run.md
+++ b/.changeset/orange-bears-run.md
@@ -2,4 +2,18 @@
 'cf-bindings-proxy': patch
 ---
 
-Fix accessing an instance of a binding multiple times interfacing on the same instance - create a new proxy instance for each time the binding is accessed.
+Fix accessing an instance of a binding through a variable multiple times interfacing on the same instance - create a new proxy instance for each time the binding is accessed.
+
+The below code is a good example of this fix. Previously, each time an action was performed using the `d1` variable, it was always interfacing with the same instance. This change fixes that, so that each time the `d1` variable is accessed below, it is interfacing with an entirely new instance of the binding. This prevents different actions on a binding via a variable from breaking each other.
+
+```ts
+const insertQuery = [
+	`INSERT INTO comments (author, body, post_slug) VALUES ('Markus', 'Hello there!', ?);`,
+	`INSERT INTO comments (author, body, post_slug) VALUES ('Kristian', 'Great post!', ?);`,
+];
+
+const d1 = binding<D1Database>('D1');
+
+const statements = insertQuery.map((query) => d1.prepare(query).bind('hello-world'));
+await d1.batch(statements);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,12 @@ export const binding = <T>(id: string): T => {
 		process.env.ENABLE_BINDINGS_PROXY ||
 		(!process.env.DISABLE_BINDINGS_PROXY && process.env.NODE_ENV === 'development')
 	) {
-		return createBindingProxy<T>(id);
+		return new Proxy(
+			{},
+			{
+				get: (_, prop) => createBindingProxy<T>(id)[prop as keyof T],
+			},
+		) as T;
 	}
 
 	return process.env[id] as T;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -109,10 +109,6 @@ export const createBindingProxy = <T>(bindingId: string, notChainable = false): 
 			if (!target.__chainUntil.length) {
 				// eslint-disable-next-line no-param-reassign
 				target.__chainUntil = shouldChainUntil(prop);
-
-				// ensure the internal calls tracker is reset in case of multiple calls from single instance
-				// eslint-disable-next-line no-param-reassign
-				target.__calls = [];
 			}
 
 			// if we haven't reached the point where we should stop chaining, return a new proxy

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -110,11 +110,11 @@ suite('bindings', () => {
 				`INSERT INTO comments (author, body, post_slug) VALUES ('Kristian', 'Great post!', ?);`,
 			];
 
-			const statements = insertQuery.map((query) =>
-				binding<D1Database>('D1').prepare(query).bind('hello-world'),
-			);
+			const d1 = binding<D1Database>('D1');
 
-			const result = await binding<D1Database>('D1').batch(statements);
+			const statements = insertQuery.map((query) => d1.prepare(query).bind('hello-world'));
+
+			const result = await d1.batch(statements);
 			expect(result.map((r) => r.success)).toEqual([true, true]);
 		});
 


### PR DESCRIPTION
This PR fixes a critical issue where accessing a binding through a variable multiple times was interfacing with the same instance.

The below code is a good example of this fix. Previously, each time an action was performed using the `d1` variable, it was always interfacing with the same instance. This change fixes that, so that each time the `d1` variable is accessed below, it is interfacing with an entirely new instance of the binding. This prevents different actions on a binding via a variable from breaking each other.

```ts
const insertQuery = [
	`INSERT INTO comments (author, body, post_slug) VALUES ('Markus', 'Hello there!', ?);`,
	`INSERT INTO comments (author, body, post_slug) VALUES ('Kristian', 'Great post!', ?);`,
];

const d1 = binding<D1Database>('D1');

const statements = insertQuery.map((query) => d1.prepare(query).bind('hello-world'));
await d1.batch(statements);
```