### PR TITLE
fix: invalid array index returning asyncfunction

### DIFF
--- a/.changeset/gentle-pets-hunt.md
+++ b/.changeset/gentle-pets-hunt.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Fix retrieving undefined array value at index returning proxy func instead of undefined.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -60,6 +60,10 @@ const createResponseProxy = <T extends object>(
 				return data[prop as keyof typeof data];
 			}
 
+			if (Array.isArray(data) && typeof prop === 'string' && !Number.isNaN(Number(prop))) {
+				return data[Number(prop)];
+			}
+
 			// eslint-disable-next-line @typescript-eslint/no-use-before-define
 			const newProxy = createBindingProxy<BindingRequest>(bindingId, true);
 

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -188,6 +188,10 @@ suite('bindings', () => {
 				['Jon', 'd1-guide'],
 				['Markus', 'hello-world'],
 			]);
+
+			expect(raw[0]).toEqual(['Jon', 'd1-guide']);
+			expect(raw[1]).toEqual(['Markus', 'hello-world']);
+			expect(raw[2]).toEqual(undefined);
 		});
 
 		test('prepare -> raw (sqlite_schema)', async () => {


### PR DESCRIPTION
This PR does the following:
- Checks if the type of the data is an array and the prop is a number. If so, it returns the value of the index.

fixes #12