### PR TITLE
[Fix] Use UTC for fallback compatibility_date

### DIFF
--- a/.changeset/hot-snakes-flow.md
+++ b/.changeset/hot-snakes-flow.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+[Fix] Use UTC for fallback compatibility_date

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,7 +31,9 @@ Please report any issues to https://github.com/james-elicx/cf-bindings-proxy
 
 	if (!passThroughArgs.includes('compatibility-date')) {
 		const date = new Date();
-		const formatted = `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+		const formatted = `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(
+			date.getUTCDate(),
+		)}`;
 		passThroughArgs.push(`--compatibility-date=${formatted}`);
 	}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,7 +31,7 @@ Please report any issues to https://github.com/james-elicx/cf-bindings-proxy
 
 	if (!passThroughArgs.includes('compatibility-date')) {
 		const date = new Date();
-		const formatted = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+		const formatted = `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
 		passThroughArgs.push(`--compatibility-date=${formatted}`);
 	}
 


### PR DESCRIPTION
### **Error**
Proxy fails to run due to compatibility_date conflict.

### **Solution**
Use UTC date values for setting fallback compatibility_date. Otherwise devs on different timezone might encounter weird bugs like this.

```
⎔ Starting local server...
✘ [ERROR] Error reloading local server: MiniflareCoreError [ERR_FUTURE_COMPATIBILITY_DATE]: Compatibility date "2023-08-03" is in the future and unsupported
```

<img width="913" alt="Screenshot 2023-08-03 at 1 32 13 AM" src="https://github.com/james-elicx/cf-bindings-proxy/assets/4602725/6b545d0e-d65f-4d2b-b1b2-bb6adfd2c367">
