### PR TITLE
Make the cache option always be no-store

### DIFF
--- a/.changeset/plenty-baboons-attend.md
+++ b/.changeset/plenty-baboons-attend.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Make the cache option always be no-store

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,6 +16,7 @@ const fetchData = async (call: BindingRequest): Promise<unknown> => {
 		resp = await fetch('http://127.0.0.1:8799', {
 			body: JSON.stringify(call),
 			method: 'POST',
+			cache: 'no-store',
 			headers: { 'Content-Type': 'application/json' },
 		});
 	} catch (e) {


### PR DESCRIPTION
When using Next.js, the default behavior of fetch is overridden so that the response is [always cached](https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache).
To solve this problem, you must explicitly specify the no-store cache option to disable caching.