### PR TITLE
feat: support for using a custom port

### DIFF
--- a/.changeset/light-points-impress.md
+++ b/.changeset/light-points-impress.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': minor
+---
+
+Support for using a custom port with the environment variable `BINDINGS_PROXY_PORT`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const value = await binding<KVNamespace>('MY_KV').get('key');
 
 ## How It Works
 
-Starting the proxy spawns an instance of Wrangler using a template, passing through any commands and bindings that are supplied to the CLI. It uses port `8799`.
+Starting the proxy spawns an instance of Wrangler using a template, passing through any commands and bindings that are supplied to the CLI. It uses port `8799` by default, but can be configured with the environment variable `BINDINGS_PROXY_PORT`.
 
 In development mode, when interacting with a binding through the `binding('BINDING_NAME')` function, it sends HTTP requests to the proxy. These HTTP requests contain destructured function calls, which are then reconstructed and executed inside the proxy. The result is then returned to the client.
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -4,6 +4,9 @@ declare global {
 			NODE_ENV?: string;
 			DISABLE_BINDINGS_PROXY?: string;
 			ENABLE_BINDINGS_PROXY?: string;
+			BINDINGS_PROXY_PROTOCOL?: string;
+			BINDINGS_PROXY_HOST?: string;
+			BINDINGS_PROXY_PORT?: string;
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"build:watch": "npm run build --watch",
 		"lint": "eslint \"./**/*.{cjs,js,jsx,ts,tsx}\"",
 		"prettier": "prettier --ignore-unknown --ignore-path=.gitignore --check .",
-		"prettier:format": "prettier --ignore-unknown --ignore-path=.gitignore --write .",
+		"prettier:fix": "prettier --ignore-unknown --ignore-path=.gitignore --write .",
 		"tsc": "tsc --noEmit",
 		"test": "vitest run",
 		"test:kill": "rm -rf .wrangler; sudo kill -9 `sudo lsof -i :8799 -t`",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PORT } from '../constants';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __filename = fileURLToPath(import.meta.url);
@@ -39,7 +40,14 @@ Please report any issues to https://github.com/james-elicx/cf-bindings-proxy
 
 	const wrangler = spawn(
 		executor,
-		['wrangler', 'pages', 'dev', resolve(__dirname, 'template'), '--port=8799', ...passThroughArgs],
+		[
+			'wrangler',
+			'pages',
+			'dev',
+			resolve(__dirname, 'template'),
+			`--port=${PORT}`,
+			...passThroughArgs,
+		],
 		{ stdio: 'inherit' },
 	);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const PROTOCOL = process.env.BINDINGS_PROXY_PROTOCOL || 'http';
+export const HOST = process.env.BINDINGS_PROXY_HOST || '127.0.0.1';
+export const PORT = Number(process.env.BINDINGS_PROXY_PORT) || 8799;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,4 @@
+import { HOST, PORT, PROTOCOL } from './constants';
 import { transformData } from './transform';
 
 export type BindingResponse =
@@ -13,7 +14,7 @@ export type BindingResponse =
 const fetchData = async (call: BindingRequest): Promise<unknown> => {
 	let resp: Response;
 	try {
-		resp = await fetch('http://127.0.0.1:8799', {
+		resp = await fetch(`${PROTOCOL}://${HOST}:${PORT}`, {
 			body: JSON.stringify(call),
 			method: 'POST',
 			cache: 'no-store',


### PR DESCRIPTION
This PR does the following:
- Allows using a custom port through the `BINDINGS_PROXY_PORT` environment variable.