### PR TITLE
fix: calling with symbol throwing error on `startsWith` check

### DIFF
--- a/.changeset/chatty-cups-impress.md
+++ b/.changeset/chatty-cups-impress.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Symbol call throwing error due to prop check assuming string.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -105,7 +105,8 @@ export const createBindingProxy = <T>(bindingId: string, notChainable = false): 
 	return new Proxy({ __bindingId: bindingId, __calls: [], __chainUntil: [] } as BindingRequest, {
 		get(target, prop: string) {
 			// internal properties
-			if (prop.startsWith('__')) return target[prop as keyof BindingRequest];
+			if (typeof prop === 'string' && prop.startsWith('__'))
+				return target[prop as keyof BindingRequest];
 			// ignore toJSON calls
 			if (prop === 'toJSON') return undefined;
 			if (notChainable) return undefined;

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -352,4 +352,12 @@ suite('bindings', () => {
 			expect(list.objects.length).toEqual(0);
 		});
 	});
+
+	suite('other patches', () => {
+		test('Calling `binding()` with a Symbol should not throw error for `startsWith` check', () => {
+			const kv = binding<KVNamespace>('KV');
+			// @ts-expect-error - testing it doesn't throw an error, not that it works
+			expect(kv[Symbol.toStringTag]).toBeDefined();
+		});
+	});
 });


### PR DESCRIPTION
This PR does the following:
- Fixes an issue where calling the result of `binding()` with a Symbol would throw an error.