### PR TITLE
feat: option for custom fallback instead of `process.env`

### DIFF
--- a/.changeset/chatty-rocks-occur.md
+++ b/.changeset/chatty-rocks-occur.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': minor
+---
+
+Support for providing a custom fallback to use instead of `process.env`.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,21 @@ import { binding } from 'cf-bindings-proxy';
 const value = await binding<KVNamespace>('MY_KV').get('key');
 ```
 
+It is also possible to specify a custom fallback for use in production instead of `process.env`.
+
+```ts
+import { binding } from 'cf-bindings-proxy';
+
+const value = await binding<KVNamespace>('MY_KV', { fallback: platform.env }).get('key');
+```
+
 ## How It Works
 
 Starting the proxy spawns an instance of Wrangler using a template, passing through any commands and bindings that are supplied to the CLI. It uses port `8799`.
 
 In development mode, when interacting with a binding through the `binding('BINDING_NAME')` function, it sends HTTP requests to the proxy. These HTTP requests contain destructured function calls, which are then reconstructed and executed inside the proxy. The result is then returned to the client.
 
-When building for production, `binding('BINDING_NAME')` simply calls `process.env.BINDING_NAME` to retrieve the binding instead.
+When building for production, `binding('BINDING_NAME')` simply calls `process.env.BINDING_NAME` to retrieve the binding instead. If you wish to use a custom fallback like `platform.env` instead of `process.env`, you can pass a custom fallback to the binding call with `binding('BINDING_NAME', { fallback: platform.env })`.
 
 ### When It's Active
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export const binding = <T>(id: string, opts?: BindingOpts): T => {
 		) as T;
 	}
 
-	return (opts?.fallback ?? process?.env)[id] as T;
+	return (opts?.fallback ?? process?.env)?.[id] as T;
 };
 
 type BindingOpts = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,20 @@ import { createBindingProxy } from './proxy';
  * const value = await binding<KVNamespace>('MY_KV').get('key');
  * ```
  *
+ * @example
+ * By default, `process.env` is used in production, however, a custom fallback can be provided.
+ * ```ts
+ * const MY_KV = binding<KVNamespace>('MY_KV', { fallback: platform.env });
+ * ```
+ *
  * @param id Binding ID.
+ * @param opts Binding options, such as a custom fallback.
  * @returns Binding value.
  */
-export const binding = <T>(id: string): T => {
+export const binding = <T>(id: string, opts?: BindingOpts): T => {
 	if (
-		process.env.ENABLE_BINDINGS_PROXY ||
-		(!process.env.DISABLE_BINDINGS_PROXY && process.env.NODE_ENV === 'development')
+		process?.env?.ENABLE_BINDINGS_PROXY ||
+		(!process?.env?.DISABLE_BINDINGS_PROXY && process?.env?.NODE_ENV === 'development')
 	) {
 		return new Proxy(
 			{},
@@ -24,5 +31,9 @@ export const binding = <T>(id: string): T => {
 		) as T;
 	}
 
-	return process.env[id] as T;
+	return (opts?.fallback ?? process?.env)[id] as T;
+};
+
+type BindingOpts = {
+	fallback: Record<string, unknown>;
 };


### PR DESCRIPTION
This PR does the following:
- Makes it possible to provide a custom fallback as an argument. e.g. `binding('MY_KV', { fallback: platform.env })`