### PR TITLE
fix: exception thrown for large buffer -> base64 transforms

### DIFF
--- a/.changeset/selfish-mirrors-pay.md
+++ b/.changeset/selfish-mirrors-pay.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Fix a maximum stack call exception from buffer -> base64 conversion

--- a/.changeset/swift-weeks-hammer.md
+++ b/.changeset/swift-weeks-hammer.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Fix blob -> base64 call for the arraybuffer not being awaited.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cf-bindings-proxy",
-	"version": "0.2.6",
+	"version": "0.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cf-bindings-proxy",
-			"version": "0.2.6",
+			"version": "0.3.1",
 			"license": "MIT",
 			"bin": {
 				"cf-bindings-proxy": "dist/cli/index.js"
@@ -28,7 +28,7 @@
 				"vite-plugin-externalize-deps": "^0.6.0",
 				"vitest": "^0.31.0",
 				"vitest-environment-miniflare": "^2.14.0",
-				"wrangler": "^3.5.1"
+				"wrangler": "^3.6.0"
 			},
 			"peerDependencies": {
 				"@cloudflare/workers-types": ">=4",
@@ -2894,9 +2894,9 @@
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.0.tgz",
-			"integrity": "sha512-vbPcv/Hx5WYdyNg/NbcfyaBZyv9s/NVbxb7yCeC5Bq1pVocNxeL2tZmSu3Rlm4IEOTjYdGyzWQgyx0OSdORBzw==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.2.tgz",
+			"integrity": "sha512-w/EZ/jwuZF+/47mAVC2+rhR2X/gwkZ+fd1pbX7Y90D5NRaRzDQcxrHY10t6ijGiYIonCVsBSF5v1cay07bP5sg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -5940,9 +5940,9 @@
 			"dev": true
 		},
 		"node_modules/node-abi": {
-			"version": "3.46.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.46.0.tgz",
-			"integrity": "sha512-LXvP3AqTIrtvH/jllXjkNVbYifpRbt9ThTtymSMSuHmhugQLAWr99QQFTm+ZRht9ziUvdGOgB+esme1C6iE6Lg==",
+			"version": "3.47.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
+			"integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
 			"dev": true,
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -8690,9 +8690,9 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.5.1.tgz",
-			"integrity": "sha512-CnrKId+pmjTfLSidM9Ut7lUDCFWEtJyY3JT3Dk+TgYHvu2zVmMgUeQQZHZfvpVN5eaEZifNQr90KEvMLy7MhHw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.6.0.tgz",
+			"integrity": "sha512-GWs4+gIUK+086svW/TgFhhxxrl/hdW2L7WASbdc10dJT7yFmCXse0SnHiqWUxbFu3ScP2t3a3LszJ08wwolWHg==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
@@ -9266,9 +9266,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.22.1",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.1.tgz",
-			"integrity": "sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==",
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+			"integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"vite-plugin-externalize-deps": "^0.6.0",
 		"vitest": "^0.31.0",
 		"vitest-environment-miniflare": "^2.14.0",
-		"wrangler": "^3.5.1"
+		"wrangler": "^3.6.0"
 	},
 	"peerDependencies": {
 		"@cloudflare/workers-types": ">=4",

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,3 +1,5 @@
+import type { PropertyCall } from './proxy';
+
 /**
  * Transforms data from one format to another.
  *
@@ -5,9 +7,17 @@
  * @param transform Transform to apply.
  * @returns Transformed data.
  */
-export const transformData = (data: unknown, transform: { from: string; to: string }): unknown => {
+export const transformData = async (
+	data: unknown,
+	transform: { from: string; to: string },
+): Promise<unknown> => {
 	if (transform.from === 'buffer' && transform.to === 'base64') {
-		return btoa(String.fromCharCode(...new Uint8Array(data as ArrayBuffer)));
+		const bytes = new Uint8Array(data as ArrayBuffer);
+		let binary = '';
+		for (let i = 0; i < bytes.byteLength; i++) {
+			binary += String.fromCharCode(bytes[i] as number);
+		}
+		return btoa(binary);
 	}
 
 	if (transform.from === 'base64' && transform.to === 'buffer') {
@@ -15,14 +25,43 @@ export const transformData = (data: unknown, transform: { from: string; to: stri
 	}
 
 	if (transform.from === 'blob' && transform.to === 'base64') {
-		const buffer = (data as Blob).arrayBuffer();
+		const buffer = await (data as Blob).arrayBuffer();
 		return transformData(buffer, { from: 'buffer', to: 'base64' });
 	}
 
 	if (transform.from === 'base64' && transform.to === 'blob') {
-		const buffer = transformData(data, { from: 'base64', to: 'buffer' }) as ArrayBuffer;
+		const buffer = (await transformData(data, { from: 'base64', to: 'buffer' })) as ArrayBuffer;
 		return new Blob([buffer]);
 	}
 
 	return data;
 };
+
+/**
+ * Prepares the argument's data to be sent over HTTP via the binding proxy.
+ * This will transform any `ArrayBuffer` or `Blob` to `base64` and add the `transform` property.
+ *
+ * @param data The data to prepare.
+ */
+export const prepareDataForProxy = async (
+	rawData: PropertyCallArg['data'],
+	fallback: PropertyCallArg,
+): Promise<PropertyCallArg> => {
+	if (rawData instanceof ArrayBuffer) {
+		return {
+			transform: { from: 'base64', to: 'buffer' },
+			data: await transformData(rawData, { from: 'buffer', to: 'base64' }),
+		};
+	}
+
+	if (rawData instanceof Blob) {
+		return {
+			transform: { from: 'base64', to: 'blob' },
+			data: await transformData(rawData, { from: 'blob', to: 'base64' }),
+		};
+	}
+
+	return fallback;
+};
+
+type PropertyCallArg = PropertyCall['args'][0];


### PR DESCRIPTION
This PR does the following:
- Shares more of the transformation logic between the proxy and the worker.
- Fixes an issue where blob -> base64 wasn't awaited.
- Fixes issue where large arraybuffers would throw maximum call stack size exception in buffer -> base64 transformation.