### PR TITLE
fix: `JSON.stringify(...)` throwing an error

### DIFF
--- a/.changeset/green-bobcats-notice.md
+++ b/.changeset/green-bobcats-notice.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Fix using `JSON.stringify(...)` throwing an error.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -88,6 +88,8 @@ const createResponseProxy = <T extends object>(
 				return data[Number(prop)];
 			}
 
+			if (['toJSON'].includes(prop as string)) return data;
+
 			// eslint-disable-next-line @typescript-eslint/no-use-before-define
 			const newProxy = createBindingProxy<BindingRequest>(bindingId, true);
 

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -320,6 +320,8 @@ suite('bindings', () => {
 				{ key: 'json-key' },
 				{ key: 'second-key' },
 			]);
+
+			expect(JSON.stringify(list.truncated)).toEqual('false');
 		});
 
 		test('head', async () => {


### PR DESCRIPTION
This PR does the following:
- Fixes a bug where `JSON.stringify(...)` calls `toJSON()`, but the call wasn't returning the object.