### PR TITLE
feat: support for `writeHttpMetadata` for R2

### DIFF
--- a/.changeset/weak-jokes-guess.md
+++ b/.changeset/weak-jokes-guess.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': minor
+---
+
+Support for `writeHttpMetadata` for R2.

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Note: Functionality and bindings not listed below may still work but have not be
 #### R2
 
 - [x] put
-  - [ ] writeHttpMetadata
+  - [x] writeHttpMetadata
 - [x] get
-  - [ ] writeHttpMetadata
+  - [x] writeHttpMetadata
   - [x] text
   - [x] json
   - [x] arrayBuffer
@@ -106,9 +106,9 @@ Note: Functionality and bindings not listed below may still work but have not be
   - [ ] body
   - [ ] bodyUsed
 - [x] head
-  - [ ] writeHttpMetadata
+  - [x] writeHttpMetadata
 - [x] list
-  - [ ] writeHttpMetadata
+  - [x] writeHttpMetadata
 - [x] delete
 - [ ] createMultipartUpload
 - [ ] resumeMultipartUpload

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -90,6 +90,21 @@ const createResponseProxy = <T extends object>(
 
 			if (['toJSON'].includes(prop as string)) return data;
 
+			// special handling for `writeHttpMetadata`
+			if (prop === 'writeHttpMetadata' && data && typeof data === 'object') {
+				// @ts-expect-error - this is fine
+				const metadata = (data.httpMetadata || {}) as R2HTTPMetadata;
+				return (headers: Headers) => {
+					if (metadata.cacheControl) headers.set('cache-control', metadata.cacheControl);
+					if (metadata.cacheExpiry) headers.set('expires', metadata.cacheExpiry.toUTCString());
+					if (metadata.contentDisposition)
+						headers.set('content-disposition', metadata.contentDisposition);
+					if (metadata.contentEncoding) headers.set('content-encoding', metadata.contentEncoding);
+					if (metadata.contentLanguage) headers.set('content-language', metadata.contentLanguage);
+					if (metadata.contentType) headers.set('content-type', metadata.contentType);
+				};
+			}
+
 			// eslint-disable-next-line @typescript-eslint/no-use-before-define
 			const newProxy = createBindingProxy<BindingRequest>(bindingId, true);
 

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -226,7 +226,7 @@ suite('bindings', () => {
 	});
 
 	suite('r2', () => {
-		// TODO: writeHttpMetadata, uploadPart: non-string
+		// TODO: uploadPart: non-string
 
 		test('put -> string', async () => {
 			const firstFile = await binding<R2Bucket>('R2').put('first-key', 'first-value', {
@@ -310,6 +310,18 @@ suite('bindings', () => {
 			const blob = await value?.blob();
 			expect(blob).toBeInstanceOf(Blob);
 			expect(await blob?.text()).toEqual(JSON.stringify({ value: 'test' }));
+		});
+
+		test('get -> writeHttpMetadata', async () => {
+			await binding<R2Bucket>('R2').put('json-key', JSON.stringify({ value: 'test' }), {
+				httpMetadata: { contentType: 'application/json' },
+			});
+			const value = await binding<R2Bucket>('R2').get('json-key');
+
+			const headers = new Headers();
+			value?.writeHttpMetadata(headers);
+
+			expect(headers.get('content-type')).toEqual('application/json');
 		});
 
 		test('list', async () => {


### PR DESCRIPTION
This PR does the following:
- Introduces support for `writeHttpMetadata` for R2 with special handling.