### PR TITLE
fix: returning binding from awaited fn calling .then

### DIFF
--- a/.changeset/twenty-pots-rule.md
+++ b/.changeset/twenty-pots-rule.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Fixes returning a binding through an awaited function calling `.then` on `binding(...)` and throwing an error.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -150,6 +150,8 @@ export const createBindingProxy = <T>(bindingId: string, notChainable = false): 
 			// ignore toJSON calls
 			if (prop === 'toJSON') return undefined;
 			if (notChainable) return undefined;
+			// ignore then calls if there are no calls yet
+			if (target.__calls.length === 0 && prop === 'then') return undefined;
 
 			// decide if we should chain until a certain point for this call
 			if (!target.__chainUntil.length) {

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -411,5 +411,11 @@ suite('bindings', () => {
 			// @ts-expect-error - testing it doesn't throw an error, not that it works
 			expect(kv[Symbol.toStringTag]).toBeDefined();
 		});
+
+		test('Returning binding from awaited function should not try to call `then`', async () => {
+			const getBinding = async () => binding<KVNamespace>('KV');
+			const kv = await getBinding();
+			expect(kv).toBeDefined();
+		});
 	});
 });


### PR DESCRIPTION
This PR does the following:
- Fixes an issue where returning `binding(...)` from an async function would attempt to call `.then` on `binding(...)`, leading to an error getting thrown.