### PR TITLE
feat: `ReadableStream` support, and response function transformations

### DIFF
--- a/.changeset/breezy-pigs-flow.md
+++ b/.changeset/breezy-pigs-flow.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': minor
+---
+
+Support for ReadableStream with R2 `.put(...)`, and `.get(...).body`.

--- a/.changeset/mean-frogs-kick.md
+++ b/.changeset/mean-frogs-kick.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': minor
+---
+
+Transforms functions from responses when making calls in the proxy, instead of needing further HTTP calls to read their value. Support for handling binding calls that return accessors for `arrayBuffer()`, `blob()`, `text()`, `json()`, `body` + `bodyUsed`.

--- a/README.md
+++ b/README.md
@@ -97,18 +97,22 @@ Note: Functionality and bindings not listed below may still work but have not be
 
 - [x] put
   - [x] writeHttpMetadata
+  - [x] _value type_: ArrayBuffer
+  - [x] _value type_: string
+  - [x] _value type_: Blob
+  - [x] _value type_: ReadableStream
 - [x] get
   - [x] writeHttpMetadata
   - [x] text
   - [x] json
   - [x] arrayBuffer
   - [x] blob
-  - [ ] body
-  - [ ] bodyUsed
+  - [x] body
+  - [x] bodyUsed
 - [x] head
   - [x] writeHttpMetadata
 - [x] list
   - [x] writeHttpMetadata
 - [x] delete
-- [ ] createMultipartUpload
-- [ ] resumeMultipartUpload
+- [ ] createMultipartUpload (needs more tests)
+- [ ] resumeMultipartUpload (needs more tests)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cf-bindings-proxy",
-	"version": "0.3.1",
+	"version": "0.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cf-bindings-proxy",
-			"version": "0.3.1",
+			"version": "0.4.1",
 			"license": "MIT",
 			"bin": {
 				"cf-bindings-proxy": "dist/cli/index.js"

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,5 +1,47 @@
 import type { PropertyCall } from './proxy';
 
+export type TransformDataType = 'buffer' | 'blob' | 'stream' | 'base64' | 'text' | 'json';
+export type TransformRawType = ArrayBuffer | Blob | string | NonNullable<object>;
+
+type ParseTransformFrom<T extends TransformDataType> = T extends 'buffer'
+	? Extract<TransformDataType, 'base64' | 'text' | 'json'>
+	: T extends 'blob'
+	? Extract<TransformDataType, 'base64'>
+	: T extends 'stream'
+	? Extract<TransformDataType, 'base64'>
+	: T extends 'base64'
+	? Extract<TransformDataType, 'buffer' | 'blob' | 'stream'>
+	: never;
+
+export type TransformRule<
+	From extends TransformDataType = TransformDataType,
+	To extends ParseTransformFrom<From> = ParseTransformFrom<From>,
+> = {
+	from: From;
+	to: To;
+};
+
+export type ParseType<T extends TransformDataType> = T extends 'buffer'
+	? ArrayBuffer
+	: T extends 'blob'
+	? Blob
+	: T extends 'stream'
+	? ReadableStream
+	: T extends 'base64' | 'text'
+	? string
+	: T extends 'json'
+	? NonNullable<object>
+	: never;
+
+export type Functions = 'arrayBuffer' | 'blob' | 'json' | 'text' | 'body';
+export type FunctionInfo<
+	DataTransformRule extends TransformRule | undefined = TransformRule | undefined,
+	Data = DataTransformRule extends TransformRule ? ParseType<DataTransformRule['to']> : undefined,
+> = ({ data: Data; takeDataFrom?: never } | { data?: never; takeDataFrom: Functions }) & {
+	transform?: DataTransformRule;
+	asAccessor?: boolean;
+};
+
 /**
  * Transforms data from one format to another.
  *
@@ -7,34 +49,82 @@ import type { PropertyCall } from './proxy';
  * @param transform Transform to apply.
  * @returns Transformed data.
  */
-export const transformData = async (
-	data: unknown,
-	transform: { from: string; to: string },
-): Promise<unknown> => {
-	if (transform.from === 'buffer' && transform.to === 'base64') {
-		const bytes = new Uint8Array(data as ArrayBuffer);
-		let binary = '';
-		for (let i = 0; i < bytes.byteLength; i++) {
-			binary += String.fromCharCode(bytes[i] as number);
+export const transformData = async <
+	From extends TransformDataType,
+	To extends ParseTransformFrom<From>,
+>(
+	data: ParseType<From>,
+	transform: TransformRule<From, To>,
+): Promise<ParseType<To>> => {
+	switch (transform.from) {
+		case 'buffer': {
+			if (transform.to === 'blob') {
+				return new Blob([data as ParseType<'buffer'>]) as ParseType<To>;
+			}
+
+			if (transform.to === 'base64') {
+				const bytes = new Uint8Array(data as ParseType<'buffer'>);
+				let binary = '';
+				for (let i = 0; i < bytes.byteLength; i++) {
+					binary += String.fromCharCode(bytes[i] as number);
+				}
+				return btoa(binary) as ParseType<To>;
+			}
+
+			const asText = new TextDecoder().decode(data as ParseType<'buffer'>);
+			if (transform.to === 'text') return asText as ParseType<To>;
+			if (transform.to === 'json') return JSON.parse(asText) as ParseType<To>;
+			break;
 		}
-		return btoa(binary);
+		case 'blob': {
+			if (transform.to === 'base64') {
+				const buffer = await (data as Blob).arrayBuffer();
+				return transformData(buffer, { from: 'buffer', to: 'base64' }) as Promise<ParseType<To>>;
+			}
+			break;
+		}
+		case 'stream': {
+			if (transform.to === 'base64') {
+				const buffer = await (data as ReadableStream).getReader().read();
+				return transformData(buffer.value as ArrayBuffer, {
+					from: 'buffer',
+					to: 'base64',
+				}) as Promise<ParseType<To>>;
+			}
+			break;
+		}
+		case 'base64': {
+			if (transform.to === 'buffer') {
+				return Uint8Array.from(atob(data as string), (c) => c.charCodeAt(0))
+					.buffer as ParseType<To>;
+			}
+
+			if (transform.to === 'blob') {
+				const buffer = await transformData(data as ParseType<'base64'>, {
+					from: 'base64',
+					to: 'buffer',
+				});
+				return new Blob([buffer]) as ParseType<To>;
+			}
+
+			if (transform.to === 'stream') {
+				const buffer = await transformData(data as ParseType<'base64'>, {
+					from: 'base64',
+					to: 'buffer',
+				});
+				const { readable, writable } = new FixedLengthStream(buffer.byteLength);
+				const writer = writable.getWriter();
+				writer.write(buffer);
+				writer.close();
+				return readable as ParseType<To>;
+			}
+			break;
+		}
+		default:
+		// no default
 	}
 
-	if (transform.from === 'base64' && transform.to === 'buffer') {
-		return Uint8Array.from(atob(data as string), (c) => c.charCodeAt(0)).buffer;
-	}
-
-	if (transform.from === 'blob' && transform.to === 'base64') {
-		const buffer = await (data as Blob).arrayBuffer();
-		return transformData(buffer, { from: 'buffer', to: 'base64' });
-	}
-
-	if (transform.from === 'base64' && transform.to === 'blob') {
-		const buffer = (await transformData(data, { from: 'base64', to: 'buffer' })) as ArrayBuffer;
-		return new Blob([buffer]);
-	}
-
-	return data;
+	return data as unknown as ParseType<To>;
 };
 
 /**
@@ -61,7 +151,44 @@ export const prepareDataForProxy = async (
 		};
 	}
 
+	// NOTE: We can't use `instanceof` here as the value may not strictly be an instance of `ReadableStream`.
+	if (
+		rawData !== null &&
+		typeof rawData === 'object' &&
+		'getReader' in rawData &&
+		typeof rawData.getReader === 'function'
+	) {
+		return {
+			transform: { from: 'base64', to: 'stream' },
+			data: await transformData(rawData as ReadableStream, { from: 'stream', to: 'base64' }),
+		};
+	}
+
 	return fallback;
 };
 
 type PropertyCallArg = PropertyCall['args'][0];
+
+export const transformFunctionInfo = async <Fn extends FunctionInfo>(
+	{ data, takeDataFrom, transform }: Fn,
+	fns: { [key in Functions]?: FunctionInfo },
+) => {
+	// eslint-disable-next-line no-nested-ternary
+	const takenData = (
+		takeDataFrom ? await transformFunctionInfo(fns[takeDataFrom] as FunctionInfo, fns) : data
+	) as TransformRawType | (() => TransformRawType | Promise<TransformRawType>);
+
+	const transformDataFn =
+		takenData && transform
+			? async () => {
+					const derivedData =
+						typeof takenData === 'function' && !(takenData instanceof Blob)
+							? await Promise.resolve(takenData())
+							: takenData;
+
+					return Promise.resolve(transformData(derivedData, transform));
+			  }
+			: takenData ?? data;
+
+	return transformDataFn as TransformRawType | (() => TransformRawType | Promise<TransformRawType>);
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,9 @@ export default defineConfig({
 	],
 	test: {
 		environment: 'miniflare',
+		environmentOptions: {
+			compatibilityDate: '2023-09-01',
+		},
 		setupFiles: [resolve('tests', 'setup.ts')],
 	},
 });


### PR DESCRIPTION
This PR does the following:
- Improves the typing for data transformations.
- Introduces support for using a `ReadableStream` as a value in R2 `.put(...)`, and reading a stream through the response from R2 `.get(...).body`.
- Transforms/handles certain known properties from responses to binding calls; `arrayBuffer()`, `blob()`, `text()`, `json()`, `body` + `bodyUsed`.