### PR TITLE
fix: array destructuring returning not iterable

### DIFF
--- a/.changeset/modern-lizards-impress.md
+++ b/.changeset/modern-lizards-impress.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Return array responses instead of creating a new proxy for the response.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -241,6 +241,10 @@ export const createBindingProxy = <T>(bindingId: string, notChainable = false): 
 					return data;
 				}
 
+				if (Array.isArray(data)) {
+					return data;
+				}
+
 				return createResponseProxy(bindingId, target, data);
 			};
 		},

--- a/tests/proxy.spec.ts
+++ b/tests/proxy.spec.ts
@@ -118,8 +118,10 @@ suite('bindings', () => {
 
 			const statements = insertQuery.map((query) => d1.prepare(query).bind('hello-world'));
 
-			const result = await d1.batch(statements);
-			expect(result.map((r) => r.success)).toEqual([true, true]);
+			const [insert1, insert2] = await d1.batch(statements);
+
+			expect(insert1?.success).toEqual(true);
+			expect(insert2?.success).toEqual(true);
 		});
 
 		test('prepare -> bind -> all (select)', async () => {


### PR DESCRIPTION
This PR does the following:
- Returns array responses immediately instead of creating a new proxy.