### PR TITLE
fix: check process is defined when using the proxy

### DIFF
--- a/.changeset/unlucky-shrimps-laugh.md
+++ b/.changeset/unlucky-shrimps-laugh.md
@@ -1,0 +1,5 @@
+---
+'cf-bindings-proxy': patch
+---
+
+Check process is not undefined when checking whether to use the binding or not.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,9 @@ import { createBindingProxy } from './proxy';
  * `true`.
  * */
 export const isProxyEnabled = () =>
-	process?.env?.ENABLE_BINDINGS_PROXY ||
-	(!process?.env?.DISABLE_BINDINGS_PROXY && process?.env?.NODE_ENV === 'development');
+	typeof process !== 'undefined' &&
+	(process?.env?.ENABLE_BINDINGS_PROXY ||
+		(!process?.env?.DISABLE_BINDINGS_PROXY && process?.env?.NODE_ENV === 'development'));
 
 /**
  * Interfaces with a binding from the environment.


### PR DESCRIPTION
This PR does the following:
- Checks process is not undefined when checking if the proxy should be enabled.